### PR TITLE
Make store/write take a io.Reader instead of path

### DIFF
--- a/filepicker/store.go
+++ b/filepicker/store.go
@@ -69,6 +69,12 @@ func (c *Client) Store(name string, opt *StoreOpts) (*Blob, error) {
 	return c.StoreReader(name, reader, opt)
 }
 
+// StoreReader allows writing of an arbitary reader to a clients storage bucket
+// If there is no error, this function returns a blob object that contains
+// information about the stored file.
+//
+// StoreOpt defines how filepicker.io will store the data. If a nil pointer is
+// provided, this function will use default storage options.
 func (c *Client) StoreReader(name string, reader io.Reader, opt *StoreOpts) (*Blob, error) {
 	return c.store(name, reader, func() string {
 		return c.toStoreURL(opt).String()

--- a/filepicker/write.go
+++ b/filepicker/write.go
@@ -35,6 +35,7 @@ func (c *Client) Write(src *Blob, name string, opt *WriteOpts) (*Blob, error) {
 	return c.WriteReader(src, reader, opt)
 }
 
+// WriteReader TODO : (ppknap)
 func (c *Client) WriteReader(src *Blob, reader io.Reader, opt *WriteOpts) (*Blob, error) {
 	return c.store("", reader, func() string {
 		return c.toWriteURL(src, opt).String()

--- a/filepicker/write.go
+++ b/filepicker/write.go
@@ -1,6 +1,10 @@
 package filepicker
 
-import "net/url"
+import (
+	"io"
+	"net/url"
+	"os"
+)
 
 // WriteOpts structure defines a set of additional options that may be required
 // to successfully rewrite the contents of the stored file.
@@ -23,7 +27,16 @@ func (wo *WriteOpts) toValues() url.Values {
 
 // Write TODO : (ppknap)
 func (c *Client) Write(src *Blob, name string, opt *WriteOpts) (*Blob, error) {
-	return c.store(name, func() string {
+	reader, err := os.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	defer reader.Close()
+	return c.WriteReader(src, reader, opt)
+}
+
+func (c *Client) WriteReader(src *Blob, reader io.Reader, opt *WriteOpts) (*Blob, error) {
+	return c.store("", reader, func() string {
 		return c.toWriteURL(src, opt).String()
 	})
 }


### PR DESCRIPTION
Store should take a more generic io.Reader, allowing users to provide in-memory files and the like.

Update tests accordingly. Bonus: no need to test that a given file is readable, this should be handled by application logic